### PR TITLE
add a play_onchange on partner_id to be coherent with the UI

### DIFF
--- a/helpdesk_mgmt_rest_api/__manifest__.py
+++ b/helpdesk_mgmt_rest_api/__manifest__.py
@@ -11,6 +11,7 @@
         "helpdesk_mgmt",
         "base_rest",
         "base_rest_attachment",
+        "onchange_helper",
     ],
     "external_dependencies": {
         "python": [

--- a/helpdesk_mgmt_rest_api/services/ticket.py
+++ b/helpdesk_mgmt_rest_api/services/ticket.py
@@ -63,8 +63,15 @@ class TicketService(Component):
     def create(self, ticket: HelpdeskTicketRequest) -> HelpdeskTicketInfo:
         vals = self._prepare_params(ticket.dict(), mode="create")
         record = self.env[self._expose_model].create(vals)
-        if 'partner_id' in vals:
-            vals.update(record.play_onchanges(vals, ['partner_id',]))
+        if "partner_id" in vals:
+            vals.update(
+                record.play_onchanges(
+                    vals,
+                    [
+                        "partner_id",
+                    ],
+                )
+            )
             record.write(vals)
         return HelpdeskTicketInfo.from_orm(record)
 

--- a/helpdesk_mgmt_rest_api/services/ticket.py
+++ b/helpdesk_mgmt_rest_api/services/ticket.py
@@ -63,6 +63,9 @@ class TicketService(Component):
     def create(self, ticket: HelpdeskTicketRequest) -> HelpdeskTicketInfo:
         vals = self._prepare_params(ticket.dict(), mode="create")
         record = self.env[self._expose_model].create(vals)
+        if 'partner_id' in vals:
+            vals.update(record.play_onchanges(vals, ['partner_id',]))
+            record.write(vals)
         return HelpdeskTicketInfo.from_orm(record)
 
     @restapi.method(

--- a/helpdesk_mgmt_rest_api/tests/test_ticket.py
+++ b/helpdesk_mgmt_rest_api/tests/test_ticket.py
@@ -106,3 +106,15 @@ class HelpdeskTicketAuthenticatedCase(HelpdeskTicketCommonCase):
         message_data = {"body": "Also here is a picture"}
         self.service.dispatch("message_post", ticket.id, params=message_data)
         self.assertEqual(len(ticket.message_ids), 2)  # There is a technical message
+
+    def test_partner_infos(self):
+        data = self.generate_ticket_data()
+        res = self.service.dispatch("create", params=data)
+        ticket = self.env["helpdesk.ticket"].search([("id", "=", res["id"])])
+        self.assert_ticket_ok(ticket)
+        authenticated_partner_id = self.env['res.partner'].browse(
+            self.services_env.collection.env.context['authenticated_partner_id']
+        )
+        self.assertEqual(ticket.partner_id, authenticated_partner_id)
+        self.assertEqual(ticket.partner_email, authenticated_partner_id.email)
+        self.assertEqual(ticket.partner_name, authenticated_partner_id.name)

--- a/helpdesk_mgmt_rest_api/tests/test_ticket.py
+++ b/helpdesk_mgmt_rest_api/tests/test_ticket.py
@@ -112,8 +112,8 @@ class HelpdeskTicketAuthenticatedCase(HelpdeskTicketCommonCase):
         res = self.service.dispatch("create", params=data)
         ticket = self.env["helpdesk.ticket"].search([("id", "=", res["id"])])
         self.assert_ticket_ok(ticket)
-        authenticated_partner_id = self.env['res.partner'].browse(
-            self.services_env.collection.env.context['authenticated_partner_id']
+        authenticated_partner_id = self.env["res.partner"].browse(
+            self.services_env.collection.env.context["authenticated_partner_id"]
         )
         self.assertEqual(ticket.partner_id, authenticated_partner_id)
         self.assertEqual(ticket.partner_email, authenticated_partner_id.email)


### PR DESCRIPTION
when a ticket is created via the API with an authenticated partner, this will play on changes on the partner_id thus allowing the partner infos to be setted by the helpdesk_mgmt/ticket's _onchange_partner_id method. 